### PR TITLE
Fix parse_str issue with dots

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -416,9 +416,7 @@ class Url
                 return [];
             }
 
-            parse_str($this->query, $array);
-
-            return $array;
+            return $this->parser->queryStringToArray($this->query);
         } elseif (is_array($query)) {
             $query = $this->validator->query(http_build_query($query));
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -60,9 +60,29 @@ final class ParserTest extends TestCase
         $this->assertEquals($parser->getSubdomainFromHost('jobs.example.com'), 'jobs');
     }
 
-    public function testStripFromEnd()
+    /**
+     * This test especially targets a problem in parse_str() which is used in the Parser class to convert a query
+     * string to array. The problem is, that dots within keys in the query string are replaced with underscores.
+     * For more information see https://github.com/crwlrsoft/url/issues/2
+     */
+    public function testQueryStringToArray()
     {
         $parser = new \Crwlr\Url\Parser();
+
+        $this->assertEquals(
+            $parser->queryStringToArray('k.1=v.1&k.2[s.k1]=v.2&k.2[s.k2]=v.3'),
+            [
+                'k.1' => 'v.1',
+                'k.2' => [
+                    's.k1' => 'v.2',
+                    's.k2' => 'v.3',
+                ]
+            ]
+        );
+    }
+
+    public function testStripFromEnd()
+    {
         $this->assertEquals(\Crwlr\Url\Parser::stripFromEnd('examplestring', 'string'), 'example');
         $this->assertEquals(\Crwlr\Url\Parser::stripFromEnd('examplestring', 'strong'), 'examplestring');
     }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -232,7 +232,7 @@ final class UrlTest extends TestCase
         $this->assertEquals($url->domainSuffix(), 'org');
         $this->assertEquals($url->domain(), 'example.org');
         $this->assertEquals($url->host(), 'sub.sub.example.org');
-        /*$this->assertEquals(
+        $this->assertEquals(
             $url->toString(),
             'https://user:password@sub.sub.example.org:8080/some/path?some=query#fragment'
         );
@@ -244,7 +244,7 @@ final class UrlTest extends TestCase
         $this->assertEquals(
             $url->toString(),
             'https://user:password@sub.sub.example.co.uk:8080/some/path?some=query#fragment'
-        );*/
+        );
     }
 
     /**


### PR DESCRIPTION
When keys within a url query string contain dots, PHPs parse_str method converts them to underscores. That's seemingly legacy behaviour as described in #2 
Work around this issue with some regex magic :)