### PR TITLE
Fix variant argument in idn_to_ascii/idn_to_utf8

### DIFF
--- a/src/Domain.php
+++ b/src/Domain.php
@@ -93,6 +93,6 @@ class Domain
     {
         $domain = $this->__toString();
 
-        return idn_to_utf8($domain) !== $domain;
+        return Helpers::idn_to_utf8($domain) !== $domain;
     }
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -284,6 +284,34 @@ class Helpers
     }
 
     /**
+     * IDN to ASCII
+     *
+     * Wrapper method for idn_to_ascii because from PHP 7.2 on variant INTL_IDNA_VARIANT_2003 is deprecated,
+     * but still the default value for argument variant (PHP 7.4 uses INTL_IDNA_VARIANT_UTS46 as default).
+     *
+     * @param string $string
+     * @return string
+     */
+    public static function idn_to_ascii(string $string): string
+    {
+        return idn_to_ascii($string, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+    }
+
+    /**
+     * IDN to UTF-8
+     *
+     * Wrapper method for idn_to_utf8 because from PHP 7.2 on variant INTL_IDNA_VARIANT_2003 is deprecated,
+     * but still the default value for argument variant (PHP 7.4 uses INTL_IDNA_VARIANT_UTS46 as default).
+     *
+     * @param string $string
+     * @return string
+     */
+    public static function idn_to_utf8(string $string): string
+    {
+        return idn_to_utf8($string, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+    }
+
+    /**
      * Helper method for queryStringToArray
      *
      * When keys within a url query string contain dots, PHP's parse_str() method converts them to underscores. This

--- a/src/Suffixes.php
+++ b/src/Suffixes.php
@@ -68,7 +68,7 @@ class Suffixes extends Store
 
         // Not found, maybe $key is an encoded idn domain suffix, so try decoding it.
         if ($idnDecoded === false) {
-            $decodedKey = idn_to_utf8($key);
+            $decodedKey = Helpers::idn_to_utf8($key);
 
             if ($key !== $decodedKey && $this->exists($decodedKey, true)) {
                 return true;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -473,7 +473,7 @@ class Validator
         $host = self::stripPortFromAuthority($authority);
 
         if (is_string($host) && $host !== '' && !self::containsOnly($host, self::hostCharacters())) {
-            $encodedHost = idn_to_ascii($host);
+            $encodedHost = Helpers::idn_to_ascii($host);
             $url = Helpers::replaceFirstOccurrence($host, $encodedHost, $url);
         }
 
@@ -868,7 +868,7 @@ class Validator
     private static function encodeIdnAndLowercase(string $string): string
     {
         if (!self::containsOnly($string, self::hostCharacters())) {
-            $string = idn_to_ascii($string);
+            $string = Helpers::idn_to_ascii($string);
         }
 
         return strtolower($string);


### PR DESCRIPTION
Add wrapper methods for idn_to_ascii and idn_to_utf8 in Helpers, because the argument variant in these methods has the default value INTL_IDNA_VARIANT_2003 until PHP 7.4 but that value was deprecated in PHP 7.2.
PHP 7.4 defaults to INTL_IDNA_VARIANT_UTS46 which is used in the new helper methods.