### PR TITLE
Add github workflow for ci

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@ phpunit.xml export-ignore
 tests export-ignore
 git-hooks export-ignore
 bin/add-git-hooks export-ignore
+.github export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI (tests and code style)
+
+on: pull_request
+
+jobs:
+  cs:
+    name: PHP CS Fixer
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.2'
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run PHP CS Fixer
+        run: composer cs
+
+  tests:
+    name: PHPUnit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run tests
+        run: composer test


### PR DESCRIPTION
Running PHP CS Fixer on PHP 7.2 and phpunit tests on PHP 7.2, 7.3, 7.4 and 8.0. Add .github directory export-ignore to .gitattributes file. And add .editorconfig rule indent_size = 2 for .yml files.