### PR TITLE
Fix handling of already booleans

### DIFF
--- a/src/Host.php
+++ b/src/Host.php
@@ -143,10 +143,6 @@ class Host
      */
     private function domainNotEmpty(): bool
     {
-        if ($this->domain instanceof Domain && !empty($this->domain->__toString())) {
-            return true;
-        }
-
-        return false;
+        return $this->domain instanceof Domain && !empty($this->domain->__toString());
     }
 }

--- a/src/Url.php
+++ b/src/Url.php
@@ -627,11 +627,7 @@ class Url
      */
     public function isRelativeReference(): bool
     {
-        if ($this->scheme() === null) {
-            return true;
-        }
-
-        return false;
+        return $this->scheme() === null;
     }
 
     /**
@@ -931,11 +927,7 @@ class Url
      */
     private function isValidComponentName(string $componentName): bool
     {
-        if (in_array($componentName, $this->components, true)) {
-            return true;
-        }
-
-        return false;
+        return in_array($componentName, $this->components, true);
     }
 
     /**


### PR DESCRIPTION
A boolean does not need `return true/false`.