### PR TITLE
"URL" in capital letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2021-01-10
 ### Added
-- Static method to create PSR-7 URI object
+- Static method to create PSR-7 `Uri` object
   (`Url::parsePsr7('https://...')`).
 
 ### Fixed
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2020-05-11
 
 ### Added
-- Adapter class URI that implements the PSR-7 `UriInterface`.
+- Adapter class `Uri` that implements the PSR-7 `UriInterface`.
 - New methods in `Url` class:
     - `authority`: Get or set the full authority part of 
       the URL.
@@ -109,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Required PHP version is now 7.2 because PHP 7.0 and 7.1 are
   no longer actively supported.
-- Instances of the URL class can now be created from relative
+- Instances of the `Url` class can now be created from relative
   references (without scheme). In v0.1 creating a new instance
   from a relative reference threw an Exception. If your 
   application expects this behavior, you can use the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Support for PHP 8.0
     - Minor change in Validator because output of PHP's
-      parse_url is different when an URL includes a
+      parse_url is different when a URL includes a
       delimiter for query or fragment but has no actual query
       or fragment (followed by empty string).
     - Change PHP version requirement in composer.json.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,10 +125,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `urlAndComponents`: Returns an array with validated url
       as string and all single validated url components (
       `null` if invalid).
-    - `absoluteUrl`: Same as `url` but only absolute urls are
+    - `absoluteUrl`: Same as `url` but only absolute URLs are
       considered valid.
     - `absoluteUrlAndComponents`: Same as `urlAndComponents`
-      but only absolute urls are valid.
+      but only absolute URLs are valid.
 - Switch to `idn_to_ascii` and `idn_to_utf8` (respectively
   [symfony/polyfill-intl-idn](https://packagist.org/packages/symfony/polyfill-intl-idn)
   ) to handle parse internationalized domain names. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2021-01-10
 ### Added
-- Static method to create PSR-7 Uri object
+- Static method to create PSR-7 URI object
   (`Url::parsePsr7('https://...')`).
 
 ### Fixed
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2020-05-11
 
 ### Added
-- Adapter class Uri that implements the PSR-7 `UriInterface`.
+- Adapter class URI that implements the PSR-7 `UriInterface`.
 - New methods in `Url` class:
     - `authority`: Get or set the full authority part of 
       the URL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.1] - 2022-01-12
 ### Fixed
 - Resolving relative paths without leading slash against a
-  base url with an empty path.
+  base URL with an empty path.
 
 ### Changed
 - Update schemes and suffixes lists.
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`Url::parsePsr7('https://...')`).
 
 ### Fixed
-- Error when resolving something to a url with an empty path.
+- Error when resolving something to a URL with an empty path.
 
 ## [1.0.2] - 2022-01-05
 ### Changed
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Support for PHP 8.0
     - Minor change in Validator because output of PHP's
-      parse_url is different when an url includes a
+      parse_url is different when an URL includes a
       delimiter for query or fragment but has no actual query
       or fragment (followed by empty string).
     - Change PHP version requirement in composer.json.
@@ -61,17 +61,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adapter class Uri that implements the PSR-7 `UriInterface`.
 - New methods in `Url` class:
     - `authority`: Get or set the full authority part of 
-      the url.
+      the URL.
     - `userInfo`: Get or set the full userInfo part of the 
-      url.
+      URL.
     - `isRelativeReference`: Returns true when the current
-      url is a relative reference.
-    - `hasIdn`: Returns true when the current url contains
+      URL is a relative reference.
+    - `hasIdn`: Returns true when the current URL contains
       an internationalized domain name in the host
       component.
-    - `isEqualTo`: Compare the current url to another one.
+    - `isEqualTo`: Compare the current URL to another one.
     - `isComponentEqualIn`: Compare some component of the
-      current url to the same component in another url.
+      current URL to the same component in another URL.
       Also with separate methods for all available
       components:
         - `isSchemeEqualIn`
@@ -109,21 +109,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Required PHP version is now 7.2 because PHP 7.0 and 7.1 are
   no longer actively supported.
-- Instances of the Url class can now be created from relative
+- Instances of the URL class can now be created from relative
   references (without scheme). In v0.1 creating a new instance
   from a relative reference threw an Exception. If your 
   application expects this behavior, you can use the 
   `isRelativeReference` method of the `Url` object to find out
-  if the url in question is a relative reference.
+  if the URL in question is a relative reference.
 - All methods in `Validator` are now static and all the
   component validation methods (scheme, host,...) now return
   `null` instead of `false` for invalid values.
-  Further Validating a full url was split into 4 different
+  Further Validating a full URL was split into 4 different
   methods:
-    - `url`: Returns the validated url as string if input is
+    - `url`: Returns the validated URL as string if input is
       valid (`null` if invalid).
-    - `urlAndComponents`: Returns an array with validated url
-      as string and all single validated url components (
+    - `urlAndComponents`: Returns an array with validated URL
+      as string and all single validated URL components (
       `null` if invalid).
     - `absoluteUrl`: Same as `url` but only absolute URLs are
       considered valid.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ use Crwlr\Url\Url;
 ```
 
 To start using the library include composer's autoload file and import the
-URL class so you don't have to write the full namespace path again and again.
+`Url` class so you don't have to write the full namespace path again and again.
 Further code examples skip the above.
 
 ### Parsing URLs
@@ -278,7 +278,7 @@ __Output__
 https://www.example.com/foo?param=value&marco=polo
 ```
 
-Btw.: As you can see in the example above, you can use a URL object like
+Btw.: As you can see in the example above, you can use a `Url` object like
 a string because of its `__toString()` method.
 
 ### Resolving relative URLs
@@ -336,7 +336,7 @@ var_dump($url1 === $url2);
 
 var_dump(Url::parse($url1)->isEqualTo($url2));
 // Returns true, because the path /foo/bár/báz is percent-encoded
-// in the URL class to /foo/b%C3%A1r/b%C3%A1z
+// in the `Url` class to /foo/b%C3%A1r/b%C3%A1z
 ```
 
 It's also really easy to compare the same component of two different
@@ -421,7 +421,7 @@ var_dump($uri->getPath());          // => '/foo/bar'
 var_dump($uri->getQuery());         // => 'some=query'
 var_dump($uri->getFragment());      // => 'fragment'
 
-// Keep in mind an instance of URI is immutable and all the methods that change
+// Keep in mind an instance of Ùri` is immutable and all the methods that change
 // state (method names starting with "with") return a new instance:
 $newUri = $uri->withScheme('http');
 var_dump($uri->getScheme());        // => 'https'

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This package is for you when PHP's parse_url() is not enough.
 
 __Key Features:__
-* __Parse a url__ and access or modify all its __components__ separately.
+* __Parse a URL__ and access or modify all its __components__ separately.
 * Resolve any __relative reference__ you may find in an HTML document __to an
-absolute url__, based on the document's url.
-* Get not only the full __host__ of a url, but also the __registrable domain__,
+absolute URL__, based on the document's URL.
+* Get not only the full __host__ of a URL, but also the __registrable domain__,
 the __domain suffix__ and the __subdomain__ parts of the host separately
 (Thanks to the [Mozilla Public Suffix List](https://publicsuffix.org/)).
 * __Compare URLs__ or components of URLs (e.g. checking if different URLs
@@ -41,12 +41,12 @@ use Crwlr\Url\Url;
 ```
 
 To start using the library include composer's autoload file and import the
-Url class so you don't have to write the full namespace path again and again.
+URL class so you don't have to write the full namespace path again and again.
 Further code examples skip the above.
 
 ### Parsing URLs
 
-Parsing a url is easy as pie:
+Parsing a URL is easy as pie:
 
 ```php
 $url = Url::parse('https://john:123@www.example.com:8080/foo?bar=baz');
@@ -56,7 +56,7 @@ The static `parse` method of the `Url` class provides a convenient way to
 create a new instance and then access all of it's components separately.
 
 ```php
-// Accessing url components via method calls
+// Accessing URL components via method calls
 $port = $url->port();                   // => 8080
 $domainSuffix = $url->domainSuffix();   // => "com"
 $path = $url->path();                   // => "/foo"
@@ -78,8 +78,8 @@ $url = new Url('https://www.steve.jobs/');
 __Relative URLs__  
 
 New in v1.0 of this package is, that you can obtain an instance of `Url` from
-a relative url as well. Previous versions throw an `InvalidUrlException` when
-the url string doesn't contain a valid scheme component.
+a relative URL as well. Previous versions throw an `InvalidUrlException` when
+the URL string doesn't contain a valid scheme component.
 
 ```php
 $url = Url::parse('/some/path?query=string');
@@ -88,7 +88,7 @@ var_dump($url->scheme());       // => null
 var_dump($url->path());         // => '/some/path'
 ```
 
-#### Available url components
+#### Available URL components
 
 Below, you can see a visualization of all the components that are available to
 you via a `Url` object.
@@ -115,7 +115,7 @@ https://john:123@subdomain.example.com:8080/foo?bar=baz#anchor
         userInfo
 ```
 
-When a component is not present in a url (e.g. it doesn't contain user and
+When a component is not present in a URL (e.g. it doesn't contain user and
 password) the corresponding properties will return `NULL`.
 
 #### Further available component combinations
@@ -153,7 +153,7 @@ $relative = $url->relative();   // => "/foo?bar=baz#anchor"
 
 #### Parsing a query string
 
-If you're after the query of a url you may want to get it as an array. Don't
+If you're after the query of a URL you may want to get it as an array. Don't
 worry, nothing easier than that:
 
 ```php
@@ -264,7 +264,7 @@ array(4) {
 ```
 
 And that's the same for all components that are listed under the [available
-url components](#available-url-components).
+URL components](#available-url-components).
 
 And the query can even be set as an array:
 
@@ -278,14 +278,14 @@ __Output__
 https://www.example.com/foo?param=value&marco=polo
 ```
 
-Btw.: As you can see in the example above, you can use a Url object like
+Btw.: As you can see in the example above, you can use a URL object like
 a string because of its `__toString()` method.
 
 ### Resolving relative URLs
 
 When you scrape URLs from a website you will come across relative URLs like
 `/path/to/page`, `../path/to/page`, `?param=value`, `#anchor` and alike. This
-package makes it a breeze to resolve these URLs to absolute ones with the url
+package makes it a breeze to resolve these URLs to absolute ones with the URL
 of the page where they have been found on.
 
 ```php
@@ -318,10 +318,10 @@ array(4) {
 }
 ```
 
-If you pass an absolute url to `resolve()` it will just return that absolute
-url.
+If you pass an absolute URL to `resolve()` it will just return that absolute
+URL.
 
-### Comparing URLs or url components
+### Comparing URLs or URL components
 
 You may think to compare two URLs you don't need this library, but whenever
 you have URLs from an unpredictable input source, I'd recommend to use it.
@@ -336,7 +336,7 @@ var_dump($url1 === $url2);
 
 var_dump(Url::parse($url1)->isEqualTo($url2));
 // Returns true, because the path /foo/bár/báz is percent-encoded
-// in the Url class to /foo/b%C3%A1r/b%C3%A1z
+// in the URL class to /foo/b%C3%A1r/b%C3%A1z
 ```
 
 It's also really easy to compare the same component of two different
@@ -390,7 +390,7 @@ is used, so you don't need to have the
 [internationalization PHP extension](https://www.php.net/manual/de/intl.installation.php)
 installed to parse internationalized domain names.
 
-To check if a url contains an internationalized domain name you can use the
+To check if a URL contains an internationalized domain name you can use the
 `hasIdn` method:
 
 ```php
@@ -458,7 +458,7 @@ catch and handle them somehow.
 
 Mozilla's [Public Suffix List](https://publicsuffix.org/list/) is parsed and
 stored in a file in this package to be able to extract the domain suffix from
-a url's host component. It should be updated with every new release
+a URL's host component. It should be updated with every new release
 of this package. If you need to get the latest version of the list
 immediately, because a particular new suffix isn't included in the list in
 this repository, you can update it using the following composer command:

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ var_dump($uri->getPath());          // => '/foo/bar'
 var_dump($uri->getQuery());         // => 'some=query'
 var_dump($uri->getFragment());      // => 'fragment'
 
-// Keep in mind an instance of Uri is immutable and all the methods that change
+// Keep in mind an instance of URI is immutable and all the methods that change
 // state (method names starting with "with") return a new instance:
 $newUri = $uri->withScheme('http');
 var_dump($uri->getScheme());        // => 'https'
@@ -447,7 +447,7 @@ var_dump($uri->__toString());
 
 There are two Exceptions that can be thrown by the `Url` class:
 * `InvalidUrlException` when you try to create an instance from a
-  string that isn't a valid Uri.
+  string that isn't a valid URI.
 * `InvalidUrlComponentException` when you try to set an invalid
   new value for a component (scheme, host,...).
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ var_dump($uri->getPath());          // => '/foo/bar'
 var_dump($uri->getQuery());         // => 'some=query'
 var_dump($uri->getFragment());      // => 'fragment'
 
-// Keep in mind an instance of Ùri` is immutable and all the methods that change
+// Keep in mind an instance of `Uri` is immutable and all the methods that change
 // state (method names starting with "with") return a new instance:
 $newUri = $uri->withScheme('http');
 var_dump($uri->getScheme());        // => 'https'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Swiss Army knife for urls
+# Swiss Army knife for URLs
 
 This package is for you when PHP's parse_url() is not enough.
 
@@ -9,7 +9,7 @@ absolute url__, based on the document's url.
 * Get not only the full __host__ of a url, but also the __registrable domain__,
 the __domain suffix__ and the __subdomain__ parts of the host separately
 (Thanks to the [Mozilla Public Suffix List](https://publicsuffix.org/)).
-* __Compare urls__ or components of urls (e.g. checking if different urls
+* __Compare URLs__ or components of URLs (e.g. checking if different URLs
 point to the same host or domain)
 * Thanks to [symfony/polyfill-intl-idn](https://github.com/symfony/polyfill-intl-idn)
 it's also no problem to parse __internationalized domain names (IDN)__.
@@ -44,7 +44,7 @@ To start using the library include composer's autoload file and import the
 Url class so you don't have to write the full namespace path again and again.
 Further code examples skip the above.
 
-### Parsing urls
+### Parsing URLs
 
 Parsing a url is easy as pie:
 
@@ -75,7 +75,7 @@ Of course you can also get a new instance using the `new` keyword.
 $url = new Url('https://www.steve.jobs/');
 ```
 
-__Relative urls__  
+__Relative URLs__  
 
 New in v1.0 of this package is, that you can obtain an instance of `Url` from
 a relative url as well. Previous versions throw an `InvalidUrlException` when
@@ -195,10 +195,10 @@ var_dump($url->__toString());
 // string(68) "https://www.example.com/listing?page%5Bnumber%5D=4&page%5Bsize%5D=25"
 ```
 
-### Modifying urls
+### Modifying URLs
 
 All methods that are used to get a component's value can also be used to
-replace or set its value. So for example if you have an array of urls and you
+replace or set its value. So for example if you have an array of URLs and you
 want to be sure that they are all on https, you can achieve this simply by
 setting the scheme to `https` for all of them in a loop.
 
@@ -281,11 +281,11 @@ https://www.example.com/foo?param=value&marco=polo
 Btw.: As you can see in the example above, you can use a Url object like
 a string because of its `__toString()` method.
 
-### Resolving relative urls
+### Resolving relative URLs
 
-When you scrape urls from a website you will come across relative urls like
+When you scrape URLs from a website you will come across relative URLs like
 `/path/to/page`, `../path/to/page`, `?param=value`, `#anchor` and alike. This
-package makes it a breeze to resolve these urls to absolute ones with the url
+package makes it a breeze to resolve these URLs to absolute ones with the url
 of the page where they have been found on.
 
 ```php
@@ -321,10 +321,10 @@ array(4) {
 If you pass an absolute url to `resolve()` it will just return that absolute
 url.
 
-### Comparing urls or url components
+### Comparing URLs or url components
 
-You may think to compare two urls you don't need this library, but whenever
-you have urls from an unpredictable input source, I'd recommend to use it.
+You may think to compare two URLs you don't need this library, but whenever
+you have URLs from an unpredictable input source, I'd recommend to use it.
 Imagine a case like this:
 
 ```php
@@ -340,7 +340,7 @@ var_dump(Url::parse($url1)->isEqualTo($url2));
 ```
 
 It's also really easy to compare the same component of two different
-urls.
+URLs.
 
 ```php
 $url1 = Url::parse('https://u:p@www.example.com/foo?q=s#frag');

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,12 +1,12 @@
 # Upgrade from 0.x to 1.0.0
 
 - Required minimum PHP version is now 7.2.
-- Instances of the Url class can now be created from relative
+- Instances of the URL class can now be created from relative
   references (without scheme). In v0.1 creating a new instance
   from a relative reference threw an Exception. If your 
   application expects this behavior, you can use the 
   `isRelativeReference` method of the `Url` object to find out
-  if the url in question is a relative reference.
+  if the URL in question is a relative reference.
 - If you're using any other class than the `Url` class directly in
   your code, please take a look at the `CHANGELOG.md` entry for
   v1.0.0. 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,7 +1,7 @@
 # Upgrade from 0.x to 1.0.0
 
 - Required minimum PHP version is now 7.2.
-- Instances of the URL class can now be created from relative
+- Instances of the `Url` class can now be created from relative
   references (without scheme). In v0.1 creating a new instance
   from a relative reference threw an Exception. If your 
   application expects this behavior, you can use the 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "crwlr/url",
-    "description": "Swiss Army knife for urls.",
+    "description": "Swiss Army knife for URLs.",
     "keywords": [
         "crwlr",
         "url",

--- a/src/DefaultPorts.php
+++ b/src/DefaultPorts.php
@@ -7,7 +7,7 @@ use Crwlr\Url\Lists\Store;
 /**
  * Class DefaultPorts
  *
- * List of default ports for uri schemes.
+ * List of default ports for URI schemes.
  */
 
 class DefaultPorts extends Store

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -72,7 +72,7 @@ class Helpers
     }
 
     /**
-     * Builds a url from an array of url components.
+     * Builds a URL from an array of URL components.
      *
      * It doesn't do any validation and assumes the provided component values are valid!
      *
@@ -158,7 +158,7 @@ class Helpers
     }
 
     /**
-     * Converts a url query string to array.
+     * Converts a URL query string to array.
      *
      * @param string $query
      * @return string[]
@@ -175,7 +175,7 @@ class Helpers
     }
 
     /**
-     * Get the standard port for a url scheme.
+     * Get the standard port for a URL scheme.
      *
      * Uses the DefaultPorts list class or tries as fallback PHPs built-in getservbyname() function that get's
      * default ports from the /etc/services file. If no standard port is found it returns null.
@@ -348,7 +348,7 @@ class Helpers
     /**
      * Helper method for queryStringToArray
      *
-     * When keys within a url query string contain dots, PHP's parse_str() method converts them to underscores. This
+     * When keys within a URL query string contain dots, PHP's parse_str() method converts them to underscores. This
      * method works around this issue so the requested query array returns the proper keys with dots.
      *
      * @param string $query

--- a/src/Lists/Store.php
+++ b/src/Lists/Store.php
@@ -7,7 +7,7 @@ use Crwlr\Url\Exceptions\ListStoreException;
 /**
  * Class Store
  *
- * The Url Package uses lists like Mozilla's Public Suffix List that contains all public domain suffixes.
+ * The URL Package uses lists like Mozilla's Public Suffix List that contains all public domain suffixes.
  * These lists are loaded from an external source, parsed and stored in a php file in the data directory at
  * the root level.
  *

--- a/src/Lists/Store.php
+++ b/src/Lists/Store.php
@@ -7,7 +7,7 @@ use Crwlr\Url\Exceptions\ListStoreException;
 /**
  * Class Store
  *
- * The URL Package uses lists like Mozilla's Public Suffix List that contains all public domain suffixes.
+ * The `Url` Package uses lists like Mozilla's Public Suffix List that contains all public domain suffixes.
  * These lists are loaded from an external source, parsed and stored in a php file in the data directory at
  * the root level.
  *

--- a/src/Lists/Store.php
+++ b/src/Lists/Store.php
@@ -7,7 +7,7 @@ use Crwlr\Url\Exceptions\ListStoreException;
 /**
  * Class Store
  *
- * The `Url` Package uses lists like Mozilla's Public Suffix List that contains all public domain suffixes.
+ * The URL Package uses lists like Mozilla's Public Suffix List that contains all public domain suffixes.
  * These lists are loaded from an external source, parsed and stored in a php file in the data directory at
  * the root level.
  *

--- a/src/Lists/WebUpdater.php
+++ b/src/Lists/WebUpdater.php
@@ -15,7 +15,7 @@ use Exception;
 abstract class WebUpdater extends Updater
 {
     /**
-     * In a child class the url where the original list can be loaded from needs to be defined,
+     * In a child class the URL where the original list can be loaded from needs to be defined,
      * otherwise instantiating the child class will throw a ListUpdaterException.
      *
      * @var string
@@ -95,7 +95,7 @@ abstract class WebUpdater extends Updater
     private function checkUrl(): void
     {
         if (!is_string($this->url) || trim($this->url) === '') {
-            throw new ListUpdaterException('No url to load the original list from is defined.');
+            throw new ListUpdaterException('No URL to load the original list from is defined.');
         }
     }
 

--- a/src/Psr/Uri.php
+++ b/src/Psr/Uri.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 
 /**
- * Class Uri
+ * Class URI
  *
  * This is an adapter class that implements the PSR-7 UriInterface that can't be implemented
  * by the URL class itself because it isn't designed to be immutable.

--- a/src/Psr/Uri.php
+++ b/src/Psr/Uri.php
@@ -10,16 +10,16 @@ use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 
 /**
- * Class URI
+ * Class Uri
  *
  * This is an adapter class that implements the PSR-7 UriInterface that can't be implemented
- * by the URL class itself because it isn't designed to be immutable.
+ * by the `Url` class itself because it isn't designed to be immutable.
  */
 
 class Uri implements UriInterface
 {
     /**
-     * @var URL
+     * @var Uri
      */
     private $url;
 
@@ -41,7 +41,7 @@ class Uri implements UriInterface
         } elseif (is_string($url)) {
             $this->url = new Url($url);
         } else {
-            throw new InvalidArgumentException('Param URL must be either a string or an instance of Crwlr\Url\Url.');
+            throw new InvalidArgumentException('Param $url must be either a string or an instance of Crwlr\Url\Url.');
         }
 
         $this->resolver = $resolver ?? new Resolver();

--- a/src/Psr/Uri.php
+++ b/src/Psr/Uri.php
@@ -13,13 +13,13 @@ use Psr\Http\Message\UriInterface;
  * Class Uri
  *
  * This is an adapter class that implements the PSR-7 UriInterface that can't be implemented
- * by the Url class itself because it isn't designed to be immutable.
+ * by the URL class itself because it isn't designed to be immutable.
  */
 
 class Uri implements UriInterface
 {
     /**
-     * @var Url
+     * @var URL
      */
     private $url;
 
@@ -41,7 +41,7 @@ class Uri implements UriInterface
         } elseif (is_string($url)) {
             $this->url = new Url($url);
         } else {
-            throw new InvalidArgumentException('Param url must be either a string or an instance of Crwlr\Url\Url.');
+            throw new InvalidArgumentException('Param URL must be either a string or an instance of Crwlr\Url\Url.');
         }
 
         $this->resolver = $resolver ?? new Resolver();

--- a/src/Psr/Uri.php
+++ b/src/Psr/Uri.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\UriInterface;
 class Uri implements UriInterface
 {
     /**
-     * @var Uri
+     * @var Url
      */
     private $url;
 

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -7,13 +7,13 @@ use Crwlr\Url\Exceptions\InvalidUrlException;
 /**
  * Class Resolver
  *
- * This class handles resolving a relative url to an absolute one given the url where the relative one was found.
+ * This class handles resolving a relative URL to an absolute one given the URL where the relative one was found.
  */
 
 class Resolver
 {
     /**
-     * Resolve any relative reference to an absolute url against a base url.
+     * Resolve any relative reference to an absolute URL against a base URL.
      *
      * Example:
      * Base: https://www.example.com/foo/bar/baz

--- a/src/Schemes.php
+++ b/src/Schemes.php
@@ -7,7 +7,7 @@ use Crwlr\Url\Lists\Store;
 /**
  * Class Schemes
  *
- * This class gives access to the list of all uri schemes from iana.org.
+ * This class gives access to the list of all URI schemes from iana.org.
  * https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
  */
 

--- a/src/Url.php
+++ b/src/Url.php
@@ -657,7 +657,7 @@ class Url
     }
 
     /**
-     * Returns true if the current instance `Url` is equal to the URL you want to compare.
+     * Returns true if the current instance URL is equal to the URL you want to compare.
      *
      * @param Url|string $url
      * @return bool

--- a/src/Url.php
+++ b/src/Url.php
@@ -10,10 +10,10 @@ use Exception;
 use InvalidArgumentException;
 
 /**
- * Class Url
+ * Class URL
  *
- * This class is the central unit of this package. It represents a url, gives access to its components and also
- * to further functionality like resolving relative URLs to absolute ones and comparing (components of) another url to
+ * This class is the central unit of this package. It represents a URL, gives access to its components and also
+ * to further functionality like resolving relative URLs to absolute ones and comparing (components of) another URL to
  * the current instance.
  *
  * @link https://www.crwlr.software/packages/url Documentation
@@ -140,7 +140,7 @@ class Url
     }
 
     /**
-     * Returns a new Url instance with param $url.
+     * Returns a new URL instance with param $url.
      *
      * @param string $url
      * @return Url
@@ -184,7 +184,7 @@ class Url
     }
 
     /**
-     * Get or set the url authority (= [userinfo"@"]host[":"port]).
+     * Get or set the URL authority (= [userinfo"@"]host[":"port]).
      *
      * @param null|string $authority
      * @return string|null|Url
@@ -349,7 +349,7 @@ class Url
      * Get or set the domain label.
      *
      * That's the registrable domain without the domain suffix (e.g. domain: "crwlr.software" => domain label: "crwlr").
-     * It can only be set when the current url contains a host with a registrable domain.
+     * It can only be set when the current URL contains a host with a registrable domain.
      *
      * @param null|string $domainLabel
      * @return string|null|Url
@@ -378,7 +378,7 @@ class Url
      * Get or set the domain suffix.
      *
      * domain: "crwlr.software" => domain suffix: "software"
-     * It can only be set when the current url contains a host with a registrable domain.
+     * It can only be set when the current URL contains a host with a registrable domain.
      *
      * @param null|string $domainSuffix
      * @return string|null|Url
@@ -407,7 +407,7 @@ class Url
      * Get or set the subdomain.
      *
      * host: "www.crwlr.software" => subdomain: "www"
-     * It can only be set when the current url contains a host with a registrable domain.
+     * It can only be set when the current URL contains a host with a registrable domain.
      *
      * @param null|string $subdomain
      * @return string|null|Url
@@ -617,9 +617,9 @@ class Url
     }
 
     /**
-     * Is the current url a relative reference
+     * Is the current URL a relative reference
      *
-     * Returns true if the current url does not begin with a scheme.
+     * Returns true if the current URL does not begin with a scheme.
      * https://tools.ietf.org/html/rfc3986#section-4.1
      *
      * @return bool
@@ -631,11 +631,11 @@ class Url
     }
 
     /**
-     * Resolve a relative reference against the url of the current instance.
+     * Resolve a relative reference against the URL of the current instance.
      *
-     * That basically means you get an absolute url from any relative reference (link href, image src, etc.) found on
+     * That basically means you get an absolute URL from any relative reference (link href, image src, etc.) found on
      * a web page.
-     * When the provided input already is an absolute url, it's just returned as it is (except for validation changes
+     * When the provided input already is an absolute URL, it's just returned as it is (except for validation changes
      * like percent encoding).
      *
      * @param string $relativeUrl
@@ -647,7 +647,7 @@ class Url
     }
 
     /**
-     * Return true when the current url contains an internationalized domain name in the host component.
+     * Return true when the current URL contains an internationalized domain name in the host component.
      *
      * @return bool
      */
@@ -657,7 +657,7 @@ class Url
     }
 
     /**
-     * Returns true if the current instance url is equal to the url you want to compare.
+     * Returns true if the current instance URL is equal to the URL you want to compare.
      *
      * @param Url|string $url
      * @return bool
@@ -669,7 +669,7 @@ class Url
     }
 
     /**
-     * Returns true when some component is the same in the current instance and the url you want to compare.
+     * Returns true when some component is the same in the current instance and the URL you want to compare.
      *
      * @param Url|string $url
      * @param string $componentName
@@ -682,7 +682,7 @@ class Url
     }
 
     /**
-     * Returns true when the scheme component is the same in the current instance and the url you want to compare.
+     * Returns true when the scheme component is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -694,7 +694,7 @@ class Url
     }
 
     /**
-     * Returns true when the authority is the same in the current instance and the url you want to compare.
+     * Returns true when the authority is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -706,7 +706,7 @@ class Url
     }
 
     /**
-     * Returns true when the user is the same in the current instance and the url you want to compare.
+     * Returns true when the user is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -718,7 +718,7 @@ class Url
     }
 
     /**
-     * Returns true when the password is the same in the current instance and the url you want to compare.
+     * Returns true when the password is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -731,7 +731,7 @@ class Url
 
     /**
      * Returns true when the user information (both user and password) is the same in the current instance and the
-     * url you want to compare.
+     * URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -743,7 +743,7 @@ class Url
     }
 
     /**
-     * Returns true when the host component is the same in the current instance and the url you want to compare.
+     * Returns true when the host component is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -755,7 +755,7 @@ class Url
     }
 
     /**
-     * Returns true when the registrable domain is the same in the current instance and the url you want to compare.
+     * Returns true when the registrable domain is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -767,7 +767,7 @@ class Url
     }
 
     /**
-     * Returns true when the domain label is the same in the current instance and the url you want to compare.
+     * Returns true when the domain label is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -779,7 +779,7 @@ class Url
     }
 
     /**
-     * Returns true when the domain suffix is the same in the current instance and the url you want to compare.
+     * Returns true when the domain suffix is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -791,7 +791,7 @@ class Url
     }
 
     /**
-     * Returns true when the subdomain is the same in the current instance and the url you want to compare.
+     * Returns true when the subdomain is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -803,7 +803,7 @@ class Url
     }
 
     /**
-     * Returns true when the port component is the same in the current instance and the url you want to compare.
+     * Returns true when the port component is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -815,7 +815,7 @@ class Url
     }
 
     /**
-     * Returns true when the path component is the same in the current instance and the url you want to compare.
+     * Returns true when the path component is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -827,7 +827,7 @@ class Url
     }
 
     /**
-     * Returns true when the query component is the same in the current instance and the url you want to compare.
+     * Returns true when the query component is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -839,7 +839,7 @@ class Url
     }
 
     /**
-     * Returns true when the fragment component is the same in the current instance and the url you want to compare.
+     * Returns true when the fragment component is the same in the current instance and the URL you want to compare.
      *
      * @param string|Url $url
      * @return bool
@@ -867,7 +867,7 @@ class Url
     }
 
     /**
-     * Populate the url components from an array or another instance of this class
+     * Populate the URL components from an array or another instance of this class
      *
      * This method does no validation so the components coming in via an array need to be valid!
      * Population from another instance is just like cloning and it's necessary for the PSR-7 UriInterface Adapter
@@ -895,7 +895,7 @@ class Url
     }
 
     /**
-     * Parse and validate $url in case it's a string, return when it's an instance of Url or throw an Exception.
+     * Parse and validate $url in case it's a string, return when it's an instance of URL or throw an Exception.
      *
      * @param string|Url $url
      * @return Url|array|(string|int)[]
@@ -906,7 +906,7 @@ class Url
     {
         /** @phpstan-ignore-next-line */
         if (!is_string($url) && !$url instanceof Url) {
-            throw new InvalidArgumentException('Param $url must either be of type string or an instance of Url.');
+            throw new InvalidArgumentException('Param $url must either be of type string or an instance of URL.');
         }
 
         if ($url instanceof Url) {
@@ -916,7 +916,7 @@ class Url
         $validComponents = Validator::urlAndComponents($url);
 
         if (!is_array($validComponents)) {
-            throw new InvalidUrlException($url . ' is not a valid url.');
+            throw new InvalidUrlException($url . ' is not a valid URL.');
         }
 
         return $validComponents;
@@ -949,7 +949,7 @@ class Url
     }
 
     /**
-     * Regenerate the full url after changing components.
+     * Regenerate the full URL after changing components.
      *
      * @throws Exception
      */
@@ -982,7 +982,7 @@ class Url
         if ($this->path() && $this->path() !== '' && !Helpers::startsWith($this->path(), '/', 1)) {
             throw new InvalidUrlComponentException(
                 'The current path doesn\'t start with a slash which is why an authority component can\'t be ' .
-                'added to the url.'
+                'added to the URL.'
             );
         }
     }
@@ -1000,7 +1000,7 @@ class Url
     }
 
     /**
-     * Compares the current instance with another url.
+     * Compares the current instance with another URL.
      *
      * @param string|Url $compareToUrl
      * @param string|null $componentName  Compare either only a certain component of the URLs or the whole URLs if null.
@@ -1013,12 +1013,12 @@ class Url
             try {
                 $compareToUrl = new Url($compareToUrl);
             } catch (InvalidUrlException $exception) {
-                // When the url to compare is invalid (and thereby has no valid components) it (or any component)
-                // can't be equal to this url instance, so return false.
+                // When the URL to compare is invalid (and thereby has no valid components) it (or any component)
+                // can't be equal to this URL instance, so return false.
                 return false;
             }
         } elseif (!$compareToUrl instanceof Url) {
-            throw new InvalidArgumentException('Param must be either string or instance of Url.');
+            throw new InvalidArgumentException('Param must be either string or instance of URL.');
         }
 
         if ($componentName === null) {

--- a/src/Url.php
+++ b/src/Url.php
@@ -10,7 +10,7 @@ use Exception;
 use InvalidArgumentException;
 
 /**
- * Class URL
+ * Class Url
  *
  * This class is the central unit of this package. It represents a URL, gives access to its components and also
  * to further functionality like resolving relative URLs to absolute ones and comparing (components of) another URL to
@@ -140,7 +140,7 @@ class Url
     }
 
     /**
-     * Returns a new URL instance with param $url.
+     * Returns a new `Url` instance with param $url.
      *
      * @param string $url
      * @return Url
@@ -657,7 +657,7 @@ class Url
     }
 
     /**
-     * Returns true if the current instance URL is equal to the URL you want to compare.
+     * Returns true if the current instance `Url` is equal to the URL you want to compare.
      *
      * @param Url|string $url
      * @return bool
@@ -895,7 +895,7 @@ class Url
     }
 
     /**
-     * Parse and validate $url in case it's a string, return when it's an instance of URL or throw an Exception.
+     * Parse and validate $url in case it's a string, return when it's an instance of `Url` or throw an Exception.
      *
      * @param string|Url $url
      * @return Url|array|(string|int)[]
@@ -906,7 +906,7 @@ class Url
     {
         /** @phpstan-ignore-next-line */
         if (!is_string($url) && !$url instanceof Url) {
-            throw new InvalidArgumentException('Param $url must either be of type string or an instance of URL.');
+            throw new InvalidArgumentException('Param $url must either be of type string or an instance of Crwlr\Url\Url.');
         }
 
         if ($url instanceof Url) {
@@ -1014,11 +1014,11 @@ class Url
                 $compareToUrl = new Url($compareToUrl);
             } catch (InvalidUrlException $exception) {
                 // When the URL to compare is invalid (and thereby has no valid components) it (or any component)
-                // can't be equal to this URL instance, so return false.
+                // can't be equal to this `Url` instance, so return false.
                 return false;
             }
         } elseif (!$compareToUrl instanceof Url) {
-            throw new InvalidArgumentException('Param must be either string or instance of URL.');
+            throw new InvalidArgumentException('Param must be either string or instance of Crwlr\Url\Url.');
         }
 
         if ($componentName === null) {

--- a/src/Url.php
+++ b/src/Url.php
@@ -152,7 +152,7 @@ class Url
     }
 
     /**
-     * Parses $url to a new instance of the PSR-7 UriInterface compatible Uri class.
+     * Parses $url to a new instance of the PSR-7 UriInterface compatible URI class.
      *
      * @param string $url
      * @return Uri

--- a/src/Url.php
+++ b/src/Url.php
@@ -152,7 +152,7 @@ class Url
     }
 
     /**
-     * Parses $url to a new instance of the PSR-7 UriInterface compatible URI class.
+     * Parses $url to a new instance of the PSR-7 UriInterface compatible `Uri` class.
      *
      * @param string $url
      * @return Uri

--- a/src/Url.php
+++ b/src/Url.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
  * Class Url
  *
  * This class is the central unit of this package. It represents a url, gives access to its components and also
- * to further functionality like resolving relative urls to absolute ones and comparing (components of) another url to
+ * to further functionality like resolving relative URLs to absolute ones and comparing (components of) another url to
  * the current instance.
  *
  * @link https://www.crwlr.software/packages/url Documentation
@@ -1003,7 +1003,7 @@ class Url
      * Compares the current instance with another url.
      *
      * @param string|Url $compareToUrl
-     * @param string|null $componentName  Compare either only a certain component of the urls or the whole urls if null.
+     * @param string|null $componentName  Compare either only a certain component of the URLs or the whole URLs if null.
      * @return bool
      * @throws InvalidArgumentException
      */

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -13,7 +13,7 @@ class Validator
     /**
      * Validate a url
      *
-     * Returns a valid url as string or null for invalid urls.
+     * Returns a valid url as string or null for invalid URLs.
      *
      * @param string $url
      * @return string|null
@@ -670,7 +670,7 @@ class Validator
     /**
      * Filter empty string elements from array returned by parse_url()
      *
-     * In PHP 7 parsing urls containing a delimiter for a component followed by nothing or another delimiter
+     * In PHP 7 parsing URLs containing a delimiter for a component followed by nothing or another delimiter
      * (e.g. https://example.com/foo?#) returns an array without the keys (query and fragment). In PHP 8 that changed
      * and the returned array contains query and fragment with empty strings as values.
      * Remove empty string elements for the same outcome in both versions.

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -719,7 +719,7 @@ class Validator
     }
 
     /**
-     * Helper method for the URL and absoluteUrl methods.
+     * Helper method for the url and absoluteUrl methods.
      *
      * Because it's the same for both methods.
      *

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -5,15 +5,15 @@ namespace Crwlr\Url;
 /**
  * Class Validator
  *
- * This class has all the validation logic. It validates a full url or single url components.
+ * This class has all the validation logic. It validates a full URL or single URL components.
  */
 
 class Validator
 {
     /**
-     * Validate a url
+     * Validate a URL
      *
-     * Returns a valid url as string or null for invalid URLs.
+     * Returns a valid URL as string or null for invalid URLs.
      *
      * @param string $url
      * @return string|null
@@ -34,9 +34,9 @@ class Validator
     }
 
     /**
-     * Get valid url and all contained components as array
+     * Get valid URL and all contained components as array
      *
-     * Returns an array like ['url' => '...', 'scheme' => '...'] or null for invalid url.
+     * Returns an array like ['url' => '...', 'scheme' => '...'] or null for invalid URL.
      *
      * @param string $url
      * @return null|array|(string|int)[]
@@ -51,9 +51,9 @@ class Validator
     }
 
     /**
-     * Validate an absolute url
+     * Validate an absolute URL
      *
-     * Same as method url() but only an absolute url is valid. Returns null for relative references.
+     * Same as method url() but only an absolute URL is valid. Returns null for relative references.
      *
      * @param string $url
      * @return string|null
@@ -74,9 +74,9 @@ class Validator
     }
 
     /**
-     * Get valid url and all contained components as array
+     * Get valid URL and all contained components as array
      *
-     * Same as method urlAndComponents() but only an absolute url is valid. Returns null for relative references.
+     * Same as method urlAndComponents() but only an absolute URL is valid. Returns null for relative references.
      *
      * @param string $url
      * @return null|array|(string|int)[]
@@ -364,7 +364,7 @@ class Validator
      * Returns path string percent-encoded according to https://tools.ietf.org/html/rfc3986#section-3.3
      * or null for an invalid path.
      *
-     * When the url doesn't contain an authority component, it can't start with more than one slash.
+     * When the URL doesn't contain an authority component, it can't start with more than one slash.
      * If it doesn't start with a slash (relative-path reference) it must not contain a colon in the first segment.
      *
      * @param string $path
@@ -472,9 +472,9 @@ class Validator
     }
 
     /**
-     * Get all valid url components from the provided url string as array.
+     * Get all valid URL components from the provided URL string as array.
      *
-     * In case of an invalid url null is returned.
+     * In case of an invalid URL null is returned.
      *
      * @param string $url
      * @param bool $onlyAbsoluteUrl  When set to true, it will also return null when the input is a relative reference.
@@ -502,7 +502,7 @@ class Validator
     }
 
     /**
-     * Encode internationalized domain names in a url
+     * Encode internationalized domain names in a URL
      *
      * PHPs parse_url method breaks special characters in internationalized domain names. So this method
      * uses the getAuthorityFromUrl method below to find the host part, checks for not allowed characters and handles
@@ -531,10 +531,10 @@ class Validator
     }
 
     /**
-     * Manually find the authority part in a url
+     * Manually find the authority part in a URL
      *
      * PHPs parse_url method breaks special characters in internationalized domain names.
-     * This method manually extracts the authority component from a url (if exists) without breaking special characters.
+     * This method manually extracts the authority component from a URL (if exists) without breaking special characters.
      *
      * @param string $url
      * @return string|null
@@ -564,7 +564,7 @@ class Validator
     }
 
     /**
-     * Manually strip the scheme part from a url
+     * Manually strip the scheme part from a URL
      *
      * Helper method for getAuthorityFromUrl method.
      *
@@ -690,7 +690,7 @@ class Validator
     }
 
     /**
-     * Validate an array of url components.
+     * Validate an array of URL components.
      *
      * Returns an empty array when one of the components is invalid.
      *
@@ -719,7 +719,7 @@ class Validator
     }
 
     /**
-     * Helper method for the url and absoluteUrl methods.
+     * Helper method for the URL and absoluteUrl methods.
      *
      * Because it's the same for both methods.
      *
@@ -1008,7 +1008,7 @@ class Validator
     }
 
     /**
-     * Url encode all characters except those from a certain regex pattern
+     * URL encode all characters except those from a certain regex pattern
      *
      * @param string $encode
      * @param string $exceptRegexPattern

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -368,7 +368,7 @@ class Validator
      * If it doesn't start with a slash (relative-path reference) it must not contain a colon in the first segment.
      *
      * @param string $path
-     * @param bool $hasAuthority  Set to false when the uri containing that path has no authority component.
+     * @param bool $hasAuthority  Set to false when the URI containing that path has no authority component.
      * @return string|null
      */
     public static function path(string $path, bool $hasAuthority = true): ?string

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -58,7 +58,7 @@ final class ResolverTest extends TestCase
         $resolved = $resolver->resolve('/some/path', $baseUrlObject);
         $this->assertEquals('https://www.example.com/some/path', $resolved->toString());
 
-        // Base url path is directory (trailing slash)
+        // Base URL path is directory (trailing slash)
         $baseUrlObject = $this->getBaseUrlObject('https://www.example.com/foo/bar/baz/');
 
         $resolved = $resolver->resolve('test', $baseUrlObject);
@@ -102,7 +102,7 @@ final class ResolverTest extends TestCase
     }
 
     /**
-     * When resolve() is called with an absolute url as subject, it should just return this absolute url.
+     * When resolve() is called with an absolute URL as subject, it should just return this absolute URL.
      */
     public function testResolveAbsoluteUrl(): void
     {

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -707,7 +707,7 @@ final class UrlTest extends TestCase
             $url->resolve('/different/path')->toString()
         );
 
-        // More tests on resolving relative to absolute urls => see ResolverTest.php
+        // More tests on resolving relative to absolute URLs => see ResolverTest.php
     }
 
     public function testCompareUrls(): void
@@ -924,7 +924,7 @@ final class UrlTest extends TestCase
     }
 
     /**
-     * Parsing urls containing special characters like umlauts in path, query or fragment percent encodes these
+     * Parsing URLs containing special characters like umlauts in path, query or fragment percent encodes these
      * characters.
      */
     public function testParsingUrlsContainingUmlauts(): void

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -99,7 +99,7 @@ final class UrlTest extends TestCase
         $this->assertEquals('https://user:password@sub.sub.example.com:8080', $url->root); // @phpstan-ignore-line
         $this->assertEquals('/some/path?some=query#fragment', $url->relative); // @phpstan-ignore-line
 
-        // other class properties that aren't components of the parsed url should not be available.
+        // other class properties that aren't components of the parsed URL should not be available.
         $this->assertNull($url->parser); // @phpstan-ignore-line
         $this->assertNull($url->validator); // @phpstan-ignore-line
         $this->assertNull($url->resolver); // @phpstan-ignore-line
@@ -342,7 +342,7 @@ final class UrlTest extends TestCase
         $url = Url::parse('http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html');
         // Host must be lowercased as stated in https://tools.ietf.org/html/rfc3986#section-3.2.2
         $this->assertEquals('[fedc:ba98:7654:3210:fedc:ba98:7654:3210]', $url->host());
-        // Port 80 isn't contained in printed url because it's the standard port for http.
+        // Port 80 isn't contained in printed URL because it's the standard port for http.
         $this->assertEquals('http://[fedc:ba98:7654:3210:fedc:ba98:7654:3210]/index.html', $url->toString());
 
         $url = Url::parse('http://[1080:0:0:0:8:800:200C:417A]/index.html');

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -24,7 +24,7 @@ final class ValidatorTest extends TestCase
     }
 
     /**
-     * Invalid url strings.
+     * Invalid URL strings.
      */
     public function testValidateInvalidUrl(): void
     {


### PR DESCRIPTION
Contains the following documentation only changes:

- ["URLs" in caps](https://github.com/crwlrsoft/url/commit/419237136094a60ebe822fba3f4a9c69851e1958)
- ["URL" in caps](https://github.com/crwlrsoft/url/commit/dd8a52bfee3442de68df03eb5261b7ae1e0dd573)
- ["URI" in caps](https://github.com/crwlrsoft/url/commit/a99258b8d8982b0e3741496b8a74c779056e7c54)

No actual code was chagned.
This should improve the readability.

https://en.wikipedia.org/wiki/URL