### PR TITLE
Start v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '8.0'
 
       - name: Check PHP Version
         run: php -v
@@ -25,37 +25,12 @@ jobs:
       - name: Run PHP CS Fixer
         run: composer cs
 
-  tests7x:
-    name: PHPUnit tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-versions: ['7.2', '7.3', '7.4']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-
-      - name: Check PHP Version
-        run: php -v
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run tests
-        run: composer test
-
   tests8x:
     name: PHPUnit tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout code
@@ -89,7 +64,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '8.0'
 
       - name: Check PHP Version
         run: php -v

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $url = Url::parse('https://john:123@www.example.com:8080/foo?bar=baz');
 ```
 
 The static `parse` method of the `Url` class provides a convenient way to
-create a new instance and then access all of it's components separately.
+create a new instance and then access all of its components separately.
 
 ```php
 // Accessing url components via method calls
@@ -61,12 +61,6 @@ $port = $url->port();                   // => 8080
 $domainSuffix = $url->domainSuffix();   // => "com"
 $path = $url->path();                   // => "/foo"
 $fragment = $url->fragment();           // => NULL
-
-// Or as properties
-$scheme = $url->scheme;                 // => "https"
-$user = $url->user;                     // => "john"
-$host = $url->host;                     // => "www.example.com"
-$domain = $url->domain;                 // => "example.com"
 ```
 
 Of course you can also get a new instance using the `new` keyword.

--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,15 @@
         "docs": "https://www.crwlr.software/packages/url"
     },
     "require": {
-        "php" : "^7.2|^8.0",
+        "php" : "^8.0",
         "psr/http-message": "^1.0",
-        "symfony/polyfill-intl-idn": "^1.11"
+        "symfony/polyfill-intl-idn": "^1.11",
+        "crwlr/query-string": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^9.0",
         "friendsofphp/php-cs-fixer": "^3.4",
-        "phpstan/phpstan": "^1.3"
+        "phpstan/phpstan": "^1.8"
     },
     "autoload": {
         "psr-4": {
@@ -54,8 +55,5 @@
         "update-schemes": "@php bin/update-schemes",
         "update-default-ports": "@php bin/update-default-ports",
         "add-git-hooks": "@php bin/add-git-hooks"
-    },
-    "suggest": {
-        "crwlr/query-string": "The queryString() method requires this additional package"
     }
 }

--- a/src/Url.php
+++ b/src/Url.php
@@ -57,7 +57,6 @@ class Url
     private $path;
 
     /**
-     * @phpstan-ignore-next-line
      * @var string|Query|null
      */
     private $query;
@@ -110,33 +109,6 @@ class Url
     {
         $url = $this->validate($url);
         $this->populate($url);
-    }
-
-    /**
-     * @param string $name
-     * @return mixed
-     */
-    public function __get(string $name)
-    {
-        if ($this->isValidComponentName($name)) {
-            return $this->$name();
-        }
-
-        return null;
-    }
-
-    /**
-     * @param string $name
-     * @param mixed $value
-     * @return mixed
-     */
-    public function __set(string $name, $value)
-    {
-        if ($this->isValidComponentName($name)) {
-            return $this->$name($value);
-        }
-
-        return null;
     }
 
     /**
@@ -493,7 +465,7 @@ class Url
     public function query(?string $query = null)
     {
         if ($query === null) {
-            return $this->query instanceof Query ? $this->query->toString() : $this->query; // @phpstan-ignore-line
+            return $this->query instanceof Query ? $this->query->toString() : $this->query;
         } elseif ($query === '') {
             $this->query = null;
         } else {
@@ -513,8 +485,8 @@ class Url
     public function queryArray(?array $query = null)
     {
         if ($query === null) {
-            if ($this->query instanceof Query) { // @phpstan-ignore-line
-                return $this->query->toArray();  // @phpstan-ignore-line
+            if ($this->query instanceof Query) {
+                return $this->query->toArray();
             }
 
             return $this->query ? Helpers::queryStringToArray($this->query) : [];
@@ -528,7 +500,7 @@ class Url
     /**
      * @throws Exception
      */
-    public function queryString(): Query // @phpstan-ignore-line
+    public function queryString(): Query
     {
         if (version_compare(PHP_VERSION, '8.0.0', '<')) {
             throw new Exception(

--- a/tests/QueryStringTest.php
+++ b/tests/QueryStringTest.php
@@ -55,7 +55,7 @@ final class QueryStringTest extends TestCase
         $url = Url::parse('https://www.example.com/path?foo=bar');
 
         if (version_compare(PHP_VERSION, '8.0.0', '>=') && class_exists(Query::class)) {
-            $url->queryString->set('baz', 'quz'); // @phpstan-ignore-line
+            $url->queryString()->set('baz', 'quz');
 
             $this->assertEquals(['foo' => 'bar', 'baz' => 'quz'], $url->queryArray());
 

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -77,34 +77,6 @@ final class UrlTest extends TestCase
         $this->assertEquals('/some/path?some=query#fragment', $url->relative());
     }
 
-    public function testClassPropertyAccess(): void
-    {
-        $url = $this->createDefaultUrlObject();
-        $this->assertEquals('https', $url->scheme); // @phpstan-ignore-line
-        $this->assertEquals('user:password@sub.sub.example.com:8080', $url->authority); // @phpstan-ignore-line
-        $this->assertEquals('user', $url->user); // @phpstan-ignore-line
-        $this->assertEquals('password', $url->password); // @phpstan-ignore-line
-        $this->assertEquals('password', $url->pass); // @phpstan-ignore-line
-        $this->assertEquals('user:password', $url->userInfo); // @phpstan-ignore-line
-        $this->assertEquals('sub.sub.example.com', $url->host); // @phpstan-ignore-line
-        $this->assertEquals('example.com', $url->domain); // @phpstan-ignore-line
-        $this->assertEquals('example', $url->domainLabel); // @phpstan-ignore-line
-        $this->assertEquals('com', $url->domainSuffix); // @phpstan-ignore-line
-        $this->assertEquals('sub.sub', $url->subdomain); // @phpstan-ignore-line
-        $this->assertEquals(8080, $url->port); // @phpstan-ignore-line
-        $this->assertEquals('/some/path', $url->path); // @phpstan-ignore-line
-        $this->assertEquals('some=query', $url->query); // @phpstan-ignore-line
-        $this->assertEquals(['some' => 'query'], $url->queryArray); // @phpstan-ignore-line
-        $this->assertEquals('fragment', $url->fragment); // @phpstan-ignore-line
-        $this->assertEquals('https://user:password@sub.sub.example.com:8080', $url->root); // @phpstan-ignore-line
-        $this->assertEquals('/some/path?some=query#fragment', $url->relative); // @phpstan-ignore-line
-
-        // other class properties that aren't components of the parsed url should not be available.
-        $this->assertNull($url->parser); // @phpstan-ignore-line
-        $this->assertNull($url->validator); // @phpstan-ignore-line
-        $this->assertNull($url->resolver); // @phpstan-ignore-line
-    }
-
     public function testParseIdnUrl(): void
     {
         $url = new Url('https://www.юбилейный.онлайн');


### PR DESCRIPTION
Breaking changes:
* Drop __get() and __set(), so you can't access url components via magic properties anymore.
* Minimum required PHP version is now 8.0 (previously 7.2).

This now also allows to require the query-string package instead of just suggesting it.