### PR TITLE
Fix getting subdomain of URLs without subdomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2022-10-11
+### Fixed
+- When a URL doesn't contain a subdomain part, the `subdomain()` method returns `null`.
+
 ## [2.0.0] - 2022-09-15
 ### Removed
 - BREAKING: Removed access to URL components (scheme, host, path,...) via magic class properties (`$this->scheme`, `$this->host`,...). Use method calls instead (`$this->scheme()`, `$this->host()`,...).

--- a/src/Host.php
+++ b/src/Host.php
@@ -27,7 +27,10 @@ class Host
 
         if ($domainSuffix) {
             $this->domain = new Domain($this->host, $domainSuffix);
-            $this->subdomain = Helpers::stripFromEnd($this->host, '.' . $this->domain);
+
+            if ($this->host !== (string) $this->domain) {
+                $this->subdomain = Helpers::stripFromEnd($this->host, '.' . $this->domain);
+            }
         }
     }
 

--- a/tests/HostTest.php
+++ b/tests/HostTest.php
@@ -49,6 +49,17 @@ final class HostTest extends TestCase
         $this->assertEquals('foo.bar.yololo.example.com', $host->__toString());
     }
 
+    public function testEmptySubdomain(): void
+    {
+        $host = new Host('crwlr.software');
+
+        $this->assertNull($host->subdomain());
+
+        $host = new Host('www.crwlr.software');
+
+        $this->assertEquals('www', $host->subdomain());
+    }
+
     public function testDomain(): void
     {
         $host = new Host('www.example.com');

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -412,6 +412,13 @@ final class UrlTest extends TestCase
         );
     }
 
+    public function testEmptySubdomain(): void
+    {
+        $this->assertNull(Url::parse('https://crwlr.software')->subdomain());
+
+        $this->assertEquals('www', Url::parse('https://www.crwlr.software')->subdomain());
+    }
+
     /**
      * @throws InvalidUrlComponentException
      * @throws Exception


### PR DESCRIPTION
When a URL doesn't contain a subdomain part, the `subdomain()` method returns `null`. This previously returned the whole domain (/host) which was wrong/unwanted behaviour.