### PR TITLE
Remove PHPUnit as a direct requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer cs
 
   tests8x:
-    name: PHPUnit tests
+    name: Unit tests
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "crwlr/query-string": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "phpstan/phpstan": "^1.8",
         "pestphp/pest": "^1.22",


### PR DESCRIPTION
The reference not needed anymore since Pest is being used. It will still be present as a dependency of Pest itself.