### PR TITLE
Add new method Url::toPsr7()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
-
-      - name: Check PHP Version
-        run: php -v
+          php-version: '8.1'
+          coverage: none
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
@@ -26,7 +24,7 @@ jobs:
         run: composer cs
 
   tests8x:
-    name: Unit tests
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,21 +32,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
 
-      - name: Check PHP Version
-        run: php -v
-
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
-
-      - name: Install query-string package
-        run: composer require crwlr/query-string
 
       - name: Run tests
         run: composer test
@@ -59,15 +51,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
-
-      - name: Check PHP Version
-        run: php -v
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: php -v
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Run PHP CS Fixer
         run: composer cs
@@ -45,7 +45,7 @@ jobs:
         run: php -v
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Install query-string package
         run: composer require crwlr/query-string
@@ -70,7 +70,7 @@ jobs:
         run: php -v
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Run PHPStan
         run: composer stan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2023-10-21
+### Added
+- Method `toPsr7()` to conveniently get a PSR-7 compatible instance from an `Url` instance. Basically wrapper for `new Uri($urlInstance)`.
+
 ## [2.0.5] - 2023-09-19
 ### Fixed
 - Issue with resolving relative URLs.

--- a/src/Url.php
+++ b/src/Url.php
@@ -8,6 +8,7 @@ use Crwlr\Url\Exceptions\InvalidUrlException;
 use Crwlr\Url\Psr\Uri;
 use Exception;
 use InvalidArgumentException;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Class Url
@@ -726,6 +727,11 @@ class Url
     public function toString(): string
     {
         return $this->url;
+    }
+
+    public function toPsr7(): UriInterface
+    {
+        return new Uri($this);
     }
 
     /**

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -4,6 +4,7 @@ use Crwlr\Url\Exceptions\InvalidUrlComponentException;
 use Crwlr\Url\Exceptions\InvalidUrlException;
 use Crwlr\Url\Psr\Uri;
 use Crwlr\Url\Url;
+use Psr\Http\Message\UriInterface;
 
 /** @var \PHPUnit\Framework\TestCase $this */
 
@@ -946,6 +947,16 @@ test('EncodingEdgeCases', function () {
         'b%C3%A1r%20b%C3%A0z?qu%C3%A4r.y=str%C3%AFng#fr%C3%A4gm%C3%A4nt',
         $url->__toString()
     );
+});
+
+it('converts an Url instance into a PSR-7 compatible instance', function () {
+    $url = Url::parse('https://www.crwl.io/en/home');
+
+    expect($url)
+        ->not()
+        ->toBeInstanceOf(UriInterface::class)
+        ->and($url->toPsr7())
+        ->toBeInstanceOf(UriInterface::class);
 });
 
 function createDefaultUrlObject(): Url


### PR DESCRIPTION
To conveniently convert a `Url` instance into a PSR-7 compatible one.